### PR TITLE
ci: fix gitleaks secret-scan (pass GITHUB_TOKEN)

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -20,3 +20,4 @@ jobs:
         uses: gitleaks/gitleaks-action@v2
         env:
           GITLEAKS_CONFIG: .gitleaks.toml
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   scan:


### PR DESCRIPTION
gitleaks-action@v2 fails at setup with 'GITHUB_TOKEN is now required to scan pull requests', so the Secret scan check has been failing on every PR without actually scanning. Wire in the auto-provided token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)